### PR TITLE
パンくずリストの作成と実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,5 +73,6 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'active_hash'
 gem 'payjp'
-gem "aws-sdk-s3", require: false
+gem 'aws-sdk-s3', require: false
 gem 'rails-i18n'
+gem 'gretel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,9 @@ GEM
     ffi (1.13.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    gretel (4.1.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -356,6 +359,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gretel
   image_processing (~> 1.2)
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,5 @@
 <%= render "shared/second-header"%>
+<% breadcrumb :profile_edit %>
 
 <%= form_with model: @user, url: user_registration_path, class: 'registration-main', local: true do |f| %>
 

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,6 @@
 <%# cssは商品出品のものを併用しています。
 app/assets/stylesheets/items/new.css %>
+<% breadcrumb :item_edit,@item %>
 
 <div class="items-sell-contents">
   <header class="items-sell-header">

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 <div class='main'>
-
   <%# 画面上部の「人生を変えるフリマアプリ」帯部分 %>
   <div class='title-contents'>
     <h2 class='service-title'>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,3 +1,4 @@
+<% breadcrumb :item_new %>
 <div class="items-sell-contents">
   <header class="items-sell-header">
     <%= link_to image_tag('furima-logo-color.png' , size: '185x50'), "/" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,4 +1,5 @@
 <%= render "shared/header" %>
+<% breadcrumb :item,@item %>
 
 <%# 商品の概要 %>
 <div class="item-show">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
 </head>
 
 <body>
+  <%= breadcrumbs pretext: "",separator: " &rsaquo; ", class: "breadcrumbs-list" %>
   <%= yield %>
 </body>
 

--- a/app/views/purchases/index.html.erb
+++ b/app/views/purchases/index.html.erb
@@ -1,4 +1,5 @@
 <%= render "shared/second-header"%>
+<% breadcrumb :purchase, @item %>
 
 <div class='transaction-contents'>
   <div class='transaction-main'>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
-
 <%= render "shared/second-header"%>
+<% breadcrumb :profile %>
 
 <div class="item-show">
   <div class="item-box">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,5 +1,35 @@
 crumb :root do
-  link "Home", root_path
+  link "トップページ", root_path
+end
+
+crumb :profile do
+  link "プロフィール", user_path(current_user)
+  parent :root
+end
+
+crumb :profile_edit do
+  link "会員情報変更", edit_user_registration_path(user_id:current_user.id)
+  parent :profile
+end
+
+crumb :item_new do
+  link "商品の出品", new_item_path
+  parent :root
+end
+
+crumb :item do |item|
+  link "商品の概要", item_path(item)
+  parent :root,item
+end
+
+crumb :purchase do |purchase_item|
+  link "商品の購入", item_purchases_path(purchase_item)
+  parent :item,purchase_item
+end
+
+crumb :item_edit do |item|
+  link "商品の編集", edit_item_path(item)
+  parent :item,item
 end
 
 # crumb :projects do


### PR DESCRIPTION
#What
パンくずリストの作成と実装

#Way 
Webサイトを利用しているユーザーが、どのページにアクセスしているのか一目でわかるようにするため。
アクセス場所がわかることによって、サイトの巡回が行いやすくなるため。